### PR TITLE
Added an optional parameter "params" to HttpClient method performGet.

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -86,7 +86,7 @@ describe('index', () => {
 
     it('sends a get http request with correct parameters', () => {
       const spy = jest.spyOn(Request, 'get')
-      return httpClient.performGet('/some-url').then((res) => {
+      return httpClient.performGet('/some-url').then(() => {
         expect(spy).toHaveBeenCalledWith(
           {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
             'url': 'https://sandbox-api.stuart.com/some-url'},

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -72,6 +72,12 @@ describe('index', () => {
         })
 
       nock(httpClient.authenticator.environment.baseUrl)
+        .get('/some-url?param1=one&param2=two')
+        .reply(200, {
+          some: 'response'
+        })
+
+      nock(httpClient.authenticator.environment.baseUrl)
         .post('/some-url')
         .reply(200, {
           some: 'response'
@@ -80,11 +86,25 @@ describe('index', () => {
 
     it('sends a get http request with correct parameters', () => {
       const spy = jest.spyOn(Request, 'get')
-      return httpClient.performGet('/some-url').then(() => {
+      return httpClient.performGet('/some-url').then((res) => {
         expect(spy).toHaveBeenCalledWith(
           {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
             'url': 'https://sandbox-api.stuart.com/some-url'},
           expect.anything())
+      })
+    })
+
+    it('sends a get http request with correct query string parameters', () => {
+      const spy = jest.spyOn(Request, 'get')
+      const params = {param1: 'one', param2: 'two'}
+      return httpClient.performGet('/some-url', params).then(() => {
+        expect(spy).toHaveBeenCalledWith(
+          {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
+            'url': 'https://sandbox-api.stuart.com/some-url',
+            'qs': {'param1': 'one', 'param2': 'two'}
+          },
+          expect.anything()
+        )
       })
     })
 

--- a/index.js
+++ b/index.js
@@ -56,13 +56,14 @@ class HttpClient {
     this.authenticator = authenticator
   }
 
-  performGet (resource) {
+  performGet (resource, params) {
     return new Promise((resolve, reject) => {
       this.authenticator.getAccessToken().then((accessToken) => {
         let options = {
           url: this.url(resource),
           headers: this.defaultHeaders(accessToken)
         }
+        if (params) options.qs = params
 
         Request.get(options, (err, res) => resolve(
           new ApiResponse(res.statusCode, JSON.parse(res.body))))


### PR DESCRIPTION
Implementation of suggestion #3 

"params" object would allow passing query string parameters into the GET request.

Example:
`params = {"param1": "one", "param2": "two"}` would be appended to the GET request URL as 
`?param1=one&param2=two`. See _index.test.js_ for more information.