### PR TITLE
fix: gracefully handle endpoints that do not return a body in the response

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -111,6 +111,18 @@ describe('index', () => {
         )
       })
     })
+  })
+
+  describe('HttpClient#performPost', () => {
+    beforeEach(() => {
+      httpClient = new HttpClient(authenticator)
+
+      nock(httpClient.authenticator.environment.baseUrl)
+        .post('/some-url')
+        .reply(200, {
+          some: 'response'
+        })
+    })
 
     it('sends a post http request with correct parameters', () => {
       const spy = jest.spyOn(Request, 'post')

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -122,6 +122,10 @@ describe('index', () => {
         .reply(200, {
           some: 'response'
         })
+
+      nock(httpClient.authenticator.environment.baseUrl)
+        .post('/some-url-that-returns-null-body')
+        .reply(204)
     })
 
     it('sends a post http request with correct parameters', () => {
@@ -131,6 +135,17 @@ describe('index', () => {
           {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
             'url': 'https://sandbox-api.stuart.com/some-url',
             'body': '{"some":"body"}'},
+          expect.anything()
+        )
+      })
+    })
+
+    it('handles null response bodies', () => {
+      const spy = jest.spyOn(Request, 'post')
+      return httpClient.performPost('/some-url-that-returns-null-body').then(() => {
+        expect(spy).toHaveBeenCalledWith(
+          {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
+            'url': 'https://sandbox-api.stuart.com/some-url-that-returns-null-body'},
           expect.anything()
         )
       })

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class HttpClient {
         }
 
         Request.post(options, (err, res) => resolve(
-          new ApiResponse(res.statusCode, JSON.parse(res.body))))
+          new ApiResponse(res.statusCode, JSON.parse(res.body || '{}'))))
       }).catch(error => { reject(error) })
     })
   };


### PR DESCRIPTION
Resolves #13 