### PR TITLE
Fixed calls to POST /v2/deliveries/{delivery_id}/cancel

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -111,6 +111,22 @@ describe('index', () => {
         )
       })
     })
+  })
+
+  describe('HttpClient#performPost', () => {
+    beforeEach(() => {
+      httpClient = new HttpClient(authenticator)
+
+      nock(httpClient.authenticator.environment.baseUrl)
+        .post('/some-url')
+        .reply(200, {
+          some: 'response'
+        })
+
+      nock(httpClient.authenticator.environment.baseUrl)
+        .post('/some-url-that-returns-null-body')
+        .reply(204)
+    })
 
     it('sends a post http request with correct parameters', () => {
       const spy = jest.spyOn(Request, 'post')
@@ -119,6 +135,17 @@ describe('index', () => {
           {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
             'url': 'https://sandbox-api.stuart.com/some-url',
             'body': '{"some":"body"}'},
+          expect.anything()
+        )
+      })
+    })
+
+    it('handles null response bodies', () => {
+      const spy = jest.spyOn(Request, 'post')
+      return httpClient.performPost('/some-url-that-returns-null-body').then(() => {
+        expect(spy).toHaveBeenCalledWith(
+          {'headers': {'Authorization': 'Bearer new-token', 'Content-Type': 'application/json', 'User-Agent': 'stuart-client-js/' + PackageJson.version},
+            'url': 'https://sandbox-api.stuart.com/some-url-that-returns-null-body'},
           expect.anything()
         )
       })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -126,6 +126,10 @@ describe('index', () => {
       nock(httpClient.authenticator.environment.baseUrl)
         .post('/some-url-that-returns-null-body')
         .reply(204)
+
+      nock(httpClient.authenticator.environment.baseUrl)
+        .post('/make-tea')
+        .reply(418)
     })
 
     it('sends a post http request with correct parameters', () => {
@@ -148,6 +152,27 @@ describe('index', () => {
             'url': 'https://sandbox-api.stuart.com/some-url-that-returns-null-body'},
           expect.anything()
         )
+      })
+    })
+
+    it('assumes 200 responses are successful', () => {
+      const spy = jest.spyOn(Request, 'post')
+      return httpClient.performPost('/some-url').then((response) => {
+        expect(response.success()).toBe(true)
+      })
+    })
+
+    it('assumes 204 responses are successful', () => {
+      const spy = jest.spyOn(Request, 'post')
+      return httpClient.performPost('/some-url-that-returns-null-body').then((response) => {
+        expect(response.success()).toBe(true)
+      })
+    })
+
+    it('assumes non 2xx responses are failures', () => {
+      const spy = jest.spyOn(Request, 'post')
+      return httpClient.performPost('/make-tea').then((response) => {
+        expect(response.success()).toBe(false)
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class ApiResponse {
   }
 
   success () {
-    return this.statusCode === 200 || this.statusCode === 201
+    return this.statusCode >= 200 && this.statusCode < 300
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class HttpClient {
         }
 
         Request.post(options, (err, res) => resolve(
-          new ApiResponse(res.statusCode, JSON.parse(res.body))))
+          new ApiResponse(res.statusCode, JSON.parse(res.body || '{}'))))
       }).catch(error => { reject(error) })
     })
   };


### PR DESCRIPTION
- gracefully handle empty response body
- assume all 2xx responses are successful 

Resolves #13 