### PR TITLE
expose http response headers on ApiResponse

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,9 +41,10 @@ class Authenticator {
 }
 
 class ApiResponse {
-  constructor (statusCode, body) {
+  constructor (statusCode, body, headers) {
     this.statusCode = statusCode
     this.body = body
+    this.headers = headers
   }
 
   success () {
@@ -66,7 +67,7 @@ class HttpClient {
         if (params) options.qs = params
 
         Request.get(options, (err, res) => resolve(
-          new ApiResponse(res.statusCode, JSON.parse(res.body))))
+          new ApiResponse(res.statusCode, JSON.parse(res.body), res.headers)))
       }).catch(error => { reject(error) })
     })
   };
@@ -81,7 +82,7 @@ class HttpClient {
         }
 
         Request.post(options, (err, res) => resolve(
-          new ApiResponse(res.statusCode, JSON.parse(res.body || '{}'))))
+          new ApiResponse(res.statusCode, JSON.parse(res.body || '{}'), res.headers)))
       }).catch(error => { reject(error) })
     })
   };


### PR DESCRIPTION
This allows users to see the response headers including custom rate-limit related headers when using the `performGet` and `performPost` methods.

This Fixes #22 